### PR TITLE
bug: ignore the default aliases which umi-plugin-dev set

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "lint-staged": "^8.1.0",
     "np": "4",
     "prettier": "^1.15.3",
+    "react": "15.*",
+    "react-dom": "15.*",
     "rollup": "^1.1.1",
     "rollup-plugin-babel": "^4.3.2",
     "rollup-plugin-filesize": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,6 +207,12 @@ module.exports = function(api: IApi, options = {} as IOption) {
       );
     }
 
+    // remove all the default aliases which umi-plugin-dev set
+    // @see https://github.com/umijs/umi/blob/f74a7dcc3e6ee7cc4e685a0d47db8d37849cb0e0/packages/umi-build-dev/src/plugins/afwebpack-config.js#L67
+    ['react', 'react-dom', 'react-router', 'react-router-dom', 'react-router-config', 'history'].forEach(lib => {
+      delete webpackConfig.resolve.alias[lib];
+    });
+
     return webpackConfig;
   });
 

--- a/test/fixtures/ignore-default-alias/.umirc.js
+++ b/test/fixtures/ignore-default-alias/.umirc.js
@@ -1,0 +1,11 @@
+
+export default {
+  plugins: [
+    ['../../../dist/index', {
+      entry: {
+        entry: require.resolve('./src/entry'),
+      },
+      html: {}
+    }],
+  ],
+};

--- a/test/fixtures/ignore-default-alias/expected/entry.html
+++ b/test/fixtures/ignore-default-alias/expected/entry.html
@@ -1,0 +1,2 @@
+<div>hello world</div>
+<script type="text/javascript" src="/entry.js"></script>

--- a/test/fixtures/ignore-default-alias/expected/entry.js
+++ b/test/fixtures/ignore-default-alias/expected/entry.js
@@ -1,0 +1,138 @@
+/******/ (function(modules) { // webpackBootstrap
+/******/ 	// The module cache
+/******/ 	var installedModules = {};
+/******/
+/******/ 	// The require function
+/******/ 	function __webpack_require__(moduleId) {
+/******/
+/******/ 		// Check if module is in cache
+/******/ 		if(installedModules[moduleId]) {
+/******/ 			return installedModules[moduleId].exports;
+/******/ 		}
+/******/ 		// Create a new module (and put it into the cache)
+/******/ 		var module = installedModules[moduleId] = {
+/******/ 			i: moduleId,
+/******/ 			l: false,
+/******/ 			exports: {}
+/******/ 		};
+/******/
+/******/ 		// Execute the module function
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, __webpack_require__);
+/******/
+/******/ 		// Flag the module as loaded
+/******/ 		module.l = true;
+/******/
+/******/ 		// Return the exports of the module
+/******/ 		return module.exports;
+/******/ 	}
+/******/
+/******/
+/******/ 	// expose the modules object (__webpack_modules__)
+/******/ 	__webpack_require__.m = modules;
+/******/
+/******/ 	// expose the module cache
+/******/ 	__webpack_require__.c = installedModules;
+/******/
+/******/ 	// define getter function for harmony exports
+/******/ 	__webpack_require__.d = function(exports, name, getter) {
+/******/ 		if(!__webpack_require__.o(exports, name)) {
+/******/ 			Object.defineProperty(exports, name, { enumerable: true, get: getter });
+/******/ 		}
+/******/ 	};
+/******/
+/******/ 	// define __esModule on exports
+/******/ 	__webpack_require__.r = function(exports) {
+/******/ 		if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 			Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 		}
+/******/ 		Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 	};
+/******/
+/******/ 	// create a fake namespace object
+/******/ 	// mode & 1: value is a module id, require it
+/******/ 	// mode & 2: merge all properties of value into the ns
+/******/ 	// mode & 4: return value when already ns object
+/******/ 	// mode & 8|1: behave like require
+/******/ 	__webpack_require__.t = function(value, mode) {
+/******/ 		if(mode & 1) value = __webpack_require__(value);
+/******/ 		if(mode & 8) return value;
+/******/ 		if((mode & 4) && typeof value === 'object' && value && value.__esModule) return value;
+/******/ 		var ns = Object.create(null);
+/******/ 		__webpack_require__.r(ns);
+/******/ 		Object.defineProperty(ns, 'default', { enumerable: true, value: value });
+/******/ 		if(mode & 2 && typeof value != 'string') for(var key in value) __webpack_require__.d(ns, key, function(key) { return value[key]; }.bind(null, key));
+/******/ 		return ns;
+/******/ 	};
+/******/
+/******/ 	// getDefaultExport function for compatibility with non-harmony modules
+/******/ 	__webpack_require__.n = function(module) {
+/******/ 		var getter = module && module.__esModule ?
+/******/ 			function getDefault() { return module['default']; } :
+/******/ 			function getModuleExports() { return module; };
+/******/ 		__webpack_require__.d(getter, 'a', getter);
+/******/ 		return getter;
+/******/ 	};
+/******/
+/******/ 	// Object.prototype.hasOwnProperty.call
+/******/ 	__webpack_require__.o = function(object, property) { return Object.prototype.hasOwnProperty.call(object, property); };
+/******/
+/******/ 	// __webpack_public_path__
+/******/ 	__webpack_require__.p = "/";
+/******/
+/******/
+/******/ 	// Load entry module and return exports
+/******/ 	return __webpack_require__(__webpack_require__.s = 0);
+/******/ })
+/************************************************************************/
+/******/ ([
+/* 0 */
+/***/ (function(module, exports, __webpack_require__) {
+
+module.exports = __webpack_require__(1);
+
+
+/***/ }),
+/* 1 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+
+
+var _interopRequireDefault = __webpack_require__(2);
+
+var _ReactVersion = _interopRequireDefault(__webpack_require__(3));
+
+console.log(_ReactVersion.default.startsWith('15'));
+alert('foooo');
+
+/***/ }),
+/* 2 */
+/***/ (function(module, exports) {
+
+function _interopRequireDefault(obj) {
+  return obj && obj.__esModule ? obj : {
+    default: obj
+  };
+}
+
+module.exports = _interopRequireDefault;
+
+/***/ }),
+/* 3 */
+/***/ (function(module, exports, __webpack_require__) {
+
+"use strict";
+/**
+ * Copyright (c) 2013-present, Facebook, Inc.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+
+
+module.exports = '15.6.2';
+
+/***/ })
+/******/ ]);

--- a/test/fixtures/ignore-default-alias/src/entry.ejs
+++ b/test/fixtures/ignore-default-alias/src/entry.ejs
@@ -1,0 +1,1 @@
+<div>hello world</div>

--- a/test/fixtures/ignore-default-alias/src/entry.js
+++ b/test/fixtures/ignore-default-alias/src/entry.js
@@ -1,0 +1,3 @@
+import ReactVersion from 'react/lib/ReactVersion';
+console.log(ReactVersion.startsWith('15'));
+alert('foooo');


### PR DESCRIPTION
mpa 场景下项目可能依赖较老版本的 react、react-router 等，而老版本的 react-router 可能也会依赖老的 history，这种场景下打包就开可能出现找错地方的问题