### PR TITLE
fix: use core-js and regenerator-runtime instead of @babel/polyfill

### DIFF
--- a/templates/polyfill.js
+++ b/templates/polyfill.js
@@ -1,1 +1,2 @@
-require('@babel/polyfill');
+require('core-js/stable');
+require('regenerator-runtime/runtime');


### PR DESCRIPTION
compatible with umi 2.8.0, see umijs/umi#2630

```
 ERROR  Failed to compile with 1 errors                                        11:27:22 AM

This dependency was not found:

* @babel/polyfill in ./node_modules/_umi-plugin-mpa@1.2.2@umi-plugin-mpa/templates/polyfill.js

To install it, you can run: npm install --save @babel/polyfill
```